### PR TITLE
fix(package): revert Bump the webcomponents js version sha

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "es6-collections": "0.x",
     "skatejs-named-slots": "1.x",
-    "webcomponents.js": "webcomponents/webcomponentsjs#393764a5"
+    "webcomponents.js": "webcomponents/webcomponentsjs#b77ca74"
   },
   "devDependencies": {
     "cz-conventional-changelog": "1.x",


### PR DESCRIPTION
Turns out there were breaking changes in https://github.com/skatejs/web-components/pull/3 after all :(

This reverts commit 95a2b3abcebd8d66a4eda1055e62d93bba71c655.
